### PR TITLE
Preserve azimuth magnitude when applying depth bias

### DIFF
--- a/source/granhoa~.cpp
+++ b/source/granhoa~.cpp
@@ -458,7 +458,8 @@ static void build_micros(t_granhoa *x){
             double jitter_az = (u01(st)*2.0 - 1.0) * saz;
             double jitter_el = (u01(st)*2.0 - 1.0) * sel;
 
-            double az = side * clampd(abs_center + jitter_az, 0.0, M_PI);
+            double abs_az = clampd(std::fabs(abs_center + jitter_az), 0.0, M_PI);
+            double az = side * abs_az;
             // porta in [-pi,pi]
             if(az> M_PI) az-=2.0*M_PI;
             if(az<-M_PI) az+=2.0*M_PI;


### PR DESCRIPTION
## Summary
- clamp the absolute azimuth offset before reapplying the random side so negative jitter retains its magnitude
- keep the existing wrap into [-pi, pi] for micro azimuths while relying on the updated magnitude handling

## Testing
- python - <<'PY'  # verifies azimuth bounds and symmetry across depth_bias values


------
https://chatgpt.com/codex/tasks/task_e_68e58a1b223c832a893872788cb89148